### PR TITLE
[AE-247]: handle responses from backend after taking a picture

### DIFF
--- a/Alloy/ScanPassportViewController.swift
+++ b/Alloy/ScanPassportViewController.swift
@@ -130,10 +130,13 @@ internal class ScanPassportViewController: ScanBaseViewController {
                         print("evaluate", error)
                     case let .success(responseE):
                         DispatchQueue.main.async { [weak self] in
-                            if responseE.summary.outcome == "Approved" {
-                                self?.passportPicture.approved()
-                                self?.passportToken = response.token
+                            guard responseE.summary.outcome == "Approved" else {
+                                self?.passportPicture.issueAppeared(responseE.summary.outcome)
+                                return
                             }
+
+                            self?.passportPicture.approved()
+                            self?.passportToken = response.token
                         }
                     }
                 }


### PR DESCRIPTION
https://z1digitalstudio.atlassian.net/browse/AE-247

Issue: Sometimes in the passport screen, after taking a photo, the app was stuck in a loading state

Fix: Only an "Approved" response from the API was handled, ignoring some other responses (like "Too blurry"). Now the app should show an error if it gets a different result from the API and let the user take the photo again.

<details>
<summary>Preview</summary>

https://user-images.githubusercontent.com/48457119/143042486-e34a3a06-103b-4bbd-9536-672442a59a7b.MP4

</details>

