### PR TITLE
[AE-252] implement a way to disable evaluation for front-back pictures

### DIFF
--- a/Alloy/Models/Evaluation.swift
+++ b/Alloy/Models/Evaluation.swift
@@ -96,7 +96,6 @@ public struct AlloyCardEvaluationResponse: Codable {
     public let summary: Summary
 
     public struct Summary: Codable {
-        let aprovedOutcome = "Approved"
         public let outcome: String
         public let outcomeReasons: [String]
 

--- a/Alloy/Models/Evaluation.swift
+++ b/Alloy/Models/Evaluation.swift
@@ -96,8 +96,13 @@ public struct AlloyCardEvaluationResponse: Codable {
     public let summary: Summary
 
     public struct Summary: Codable {
+        let aprovedOutcome = "Approved"
         public let outcome: String
         public let outcomeReasons: [String]
+
+        var isApproved: Bool {
+            outcome == Constants.approvedOutcome
+        }
 
         private enum CodingKeys: String, CodingKey {
             case outcome = "outcome",
@@ -109,4 +114,8 @@ public struct AlloyCardEvaluationResponse: Codable {
         case entityToken = "entity_token",
              summary
     }
+}
+
+private enum Constants {
+    static let approvedOutcome = "Approved"
 }

--- a/Alloy/Models/Init.swift
+++ b/Alloy/Models/Init.swift
@@ -24,6 +24,7 @@ public struct Alloy {
     public var externalEntityId: AlloyEntityToken? = nil
     public var maxEvaluationAttempts: Int = 2
     public var production: Bool = false
+    public var validationPrecheck: Bool = true
     private(set) public var completion: AlloyResultCallback?
 
     public init(key: String, for evaluationData: AlloyEvaluationData) {

--- a/Alloy/Models/Init.swift
+++ b/Alloy/Models/Init.swift
@@ -24,7 +24,7 @@ public struct Alloy {
     public var externalEntityId: AlloyEntityToken? = nil
     public var maxEvaluationAttempts: Int = 2
     public var production: Bool = false
-    public var validationPrecheck: Bool = true
+    public var validationPreChecks: Bool = true
     private(set) public var completion: AlloyResultCallback?
 
     public init(key: String, for evaluationData: AlloyEvaluationData) {

--- a/Alloy/ScanBaseViewController.swift
+++ b/Alloy/ScanBaseViewController.swift
@@ -13,8 +13,8 @@ internal class ScanBaseViewController: UIViewController {
         return config.evaluationData
     }
 
-    internal var needsValidationPrecheck: Bool {
-        config.validationPrecheck
+    internal var needsPreChecks: Bool {
+        config.validationPreChecks
     }
 
     // MARK: Views

--- a/Alloy/ScanBaseViewController.swift
+++ b/Alloy/ScanBaseViewController.swift
@@ -13,6 +13,10 @@ internal class ScanBaseViewController: UIViewController {
         return config.evaluationData
     }
 
+    internal var needsValidationPrecheck: Bool {
+        config.validationPrecheck
+    }
+
     // MARK: Views
 
     internal lazy var scrollView = UIScrollView()

--- a/Alloy/ScanIDViewController.swift
+++ b/Alloy/ScanIDViewController.swift
@@ -174,7 +174,7 @@ internal class ScanIDViewController: ScanBaseViewController {
             case let .failure(error):
                 print("create/upload", error)
             case let .success(response):
-                guard self.needsValidationPrecheck else {
+                guard self.needsPreChecks else {
                     self.assignToken(forCard: card, token: response.token)
                     return
                 }

--- a/Alloy/ScanIDViewController.swift
+++ b/Alloy/ScanIDViewController.swift
@@ -185,7 +185,6 @@ internal class ScanIDViewController: ScanBaseViewController {
                     case let .failure(error):
                         print("evaluate", error)
                     case let .success(responseE):
-                        self.handleIssue(forCard: card, issue: "Some issue")
                         guard responseE.summary.isApproved else {
                             self.handleIssue(forCard: card, issue: responseE.summary.outcome)
                             return

--- a/Alloy/ScanPassportViewController.swift
+++ b/Alloy/ScanPassportViewController.swift
@@ -129,7 +129,7 @@ internal class ScanPassportViewController: ScanBaseViewController {
                         print("evaluate", error)
                     case let .success(responseE):
                         DispatchQueue.main.async { [weak self] in
-                            guard responseE.summary.outcome == "Approved" else {
+                            guard responseE.summary.isApproved else {
                                 self?.passportPicture.issueAppeared(responseE.summary.outcome)
                                 return
                             }


### PR DESCRIPTION
Now you can use 

`alloy.validationPreChecks = false 
`

to avoid evaluation runs after front/bak pictures of ID Card