### PR TITLE
Ae 259/outcomes

### DIFF
--- a/Alloy/EndViewController.swift
+++ b/Alloy/EndViewController.swift
@@ -1,8 +1,11 @@
 import UIKit
+import CoreMedia
 
-internal enum EndVariant {
-    case success
-    case failure
+internal enum EndVariant: String {
+    case success = "Approved"
+    case retakeImages = "Retake Images"
+    case manualReview = "Manual Review"
+    case failure = "Denied"
 }
 
 internal class EndViewController: UIViewController {
@@ -125,32 +128,20 @@ internal class EndViewController: UIViewController {
     // MARK: Configure
 
     private func configureResponse() {
-        switch response {
-        case .none:
-            break
-
-        case .failure:
+        if case .failure = response {
             variant = .failure
+        }
 
-        case let .success(response):
-            if response.summary.outcome == "Approved" {
-                variant = .success
-            } else if response.summary.outcome == "Denied" {
-                variant = .failure
-            }
+        if case let .success(alloyResponse) = response {
+            variant = alloyResponse.endOutcome ?? .failure
         }
     }
 
     private func configureVariant() {
         banner.variant = variant
-        titleLabel.text = variant == .failure
-            ? "Denied"
-            : "Success!"
-        subtitleLabel.text = variant == .failure
-            ? "We’re sorry, your ID cant’t be validated"
-            : "Your ID has been validated"
-        mainButton.setTitle(variant == .failure ? "Retry" : "Continue", for: .normal)
-        leaveButton.isHidden = variant == .success
+        titleLabel.text = variant.modalTitle
+        subtitleLabel.text = variant.message
+        mainButton.setTitle(variant.buttonTitle, for: .normal)
     }
 
     private func configureAlloyRetry() {
@@ -176,3 +167,36 @@ internal class EndViewController: UIViewController {
         }
     }
 }
+
+private extension AlloyCardEvaluationResponse {
+    var endOutcome: EndVariant? {
+        EndVariant(rawValue: summary.outcome)
+    }
+}
+
+private extension EndVariant {
+    var modalTitle: String {
+        switch self {
+        case .failure: return "Denied"
+        case .success, .manualReview: return "Success"
+        case .retakeImages: return "Images need to be retaken"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .failure: return "We’re sorry, your ID cant’t be validated"
+        case .success: return "Your ID has been validated"
+        case .manualReview: return "Thank you! We're reviewing your images and will get back to you soon"
+        case .retakeImages: return "Please, go back and try again"
+        }
+    }
+
+    var buttonTitle: String {
+        switch self {
+        case .failure, .retakeImages: return "Retry"
+        case .success, .manualReview: return "Finish"
+        }
+    }
+}
+

--- a/Alloy/EndViewController.swift
+++ b/Alloy/EndViewController.swift
@@ -169,8 +169,8 @@ internal class EndViewController: UIViewController {
 }
 
 private extension AlloyCardEvaluationResponse {
-    var endOutcome: EndVariant? {
-        EndVariant(rawValue: summary.outcome)
+    var endOutcome: EndVariant {
+        EndVariant(rawValue: summary.outcome) ?? .manualReview
     }
 }
 

--- a/Alloy/Models/Evaluation.swift
+++ b/Alloy/Models/Evaluation.swift
@@ -145,6 +145,13 @@ public struct AlloyCardEvaluationResponse: Codable {
             outcome == Constants.approvedOutcome
         }
 
+        var hasCardIssue: Bool {
+            [Constants.approvedOutcome, Constants.deniedOutcome, Constants.manualReviewOutcome]
+                .filter { $0 == outcome }
+                .isEmpty
+                
+        }
+
         private enum CodingKeys: String, CodingKey {
             case outcome = "outcome",
                  outcomeReasons = "outcome_reasons"

--- a/Alloy/Models/Evaluation.swift
+++ b/Alloy/Models/Evaluation.swift
@@ -159,4 +159,7 @@ public struct AlloyCardEvaluationResponse: Codable {
 
 private enum Constants {
     static let approvedOutcome = "Approved"
+    static let deniedOutcome = "Denied"
+    static let manualReviewOutcome = "Manual Review"
+    static let retakeImagesOutcome = "Retake Images"
 }

--- a/Alloy/ScanBaseViewController.swift
+++ b/Alloy/ScanBaseViewController.swift
@@ -87,12 +87,14 @@ internal class ScanBaseViewController: UIViewController {
     internal func showEndScreen(for response: AlloyResult, onRetry: (() -> Void)?) {
         numberOfAttempts += 1
 
-        let vc = EndViewController()
-        vc.onRetry = onRetry
-        vc.response = response
-        vc.onCompletion = config.completion
-        vc.noMoreAttempts = numberOfAttempts >= config.maxEvaluationAttempts
-        navigationController?.pushViewController(vc, animated: true)
+        DispatchQueue.main.async {
+            let vc = EndViewController()
+            vc.onRetry = onRetry
+            vc.response = response
+            vc.onCompletion = self.config.completion
+            vc.noMoreAttempts = self.numberOfAttempts >= self.config.maxEvaluationAttempts
+            self.navigationController?.pushViewController(vc, animated: true)
+        }
     }
 
     @objc internal func takeSelfiePicture() {

--- a/Alloy/ScanIDViewController.swift
+++ b/Alloy/ScanIDViewController.swift
@@ -242,22 +242,8 @@ internal class ScanIDViewController: ScanBaseViewController {
             switch result {
             case .failure(let error):
                 self?.showEndScreen(for: .failure(error), onRetry: self?.onRetry)
-
             case .success(let response):
-                DispatchQueue.main.async {
-                    if response.summary.canShowEndModal {
-                        self?.showEndScreen(for: .success(response), onRetry: self?.onRetry)
-                        return
-                    }
-
-                    for reason in response.summary.outcomeReasons {
-                        if reason.starts(with: "Back") {
-                            self?.backCard.issueAppeared(reason)
-                        } else if reason.starts(with: "Front") {
-                            self?.frontCard.issueAppeared(reason)
-                        }
-                    }
-                }
+                self?.showEndScreen(for: .success(response), onRetry: self?.onRetry)
             }
         }
     }

--- a/Alloy/ScanIDViewController.swift
+++ b/Alloy/ScanIDViewController.swift
@@ -245,8 +245,7 @@ internal class ScanIDViewController: ScanBaseViewController {
 
             case .success(let response):
                 DispatchQueue.main.async {
-                    let outcome = response.summary.outcome
-                    if outcome == "Approved" || outcome == "Denied" {
+                    if response.summary.canShowEndModal {
                         self?.showEndScreen(for: .success(response), onRetry: self?.onRetry)
                         return
                     }

--- a/Alloy/ScanIDViewController.swift
+++ b/Alloy/ScanIDViewController.swift
@@ -219,7 +219,7 @@ internal class ScanIDViewController: ScanBaseViewController {
             case let .failure(error):
                 print("evaluate", error)
             case let .success(responseE):
-                if !responseE.summary.isApproved {
+                if responseE.summary.hasCardIssue {
                     self?.handleIssue(forCard: card, issue: responseE.summary.outcome)
                 }
             }

--- a/Alloy/ScanPassportViewController.swift
+++ b/Alloy/ScanPassportViewController.swift
@@ -178,18 +178,8 @@ internal class ScanPassportViewController: ScanBaseViewController {
             switch result {
             case .failure(let error):
                 self?.showEndScreen(for: .failure(error), onRetry: self?.onRetry)
-
             case .success(let response):
-                DispatchQueue.main.async {
-                    if response.summary.canShowEndModal {
-                        self?.showEndScreen(for: .success(response), onRetry: self?.onRetry)
-                        return
-                    }
-
-                    for reason in response.summary.outcomeReasons {
-                        self?.passportPicture.issueAppeared(reason)
-                    }
-                }
+                self?.showEndScreen(for: .success(response), onRetry: self?.onRetry)
             }
         }
     }

--- a/Alloy/ScanPassportViewController.swift
+++ b/Alloy/ScanPassportViewController.swift
@@ -181,8 +181,7 @@ internal class ScanPassportViewController: ScanBaseViewController {
 
             case .success(let response):
                 DispatchQueue.main.async {
-                    let outcome = response.summary.outcome
-                    if outcome == "Approved" || outcome == "Denied" {
+                    if response.summary.canShowEndModal {
                         self?.showEndScreen(for: .success(response), onRetry: self?.onRetry)
                         return
                     }

--- a/Alloy/ScanPassportViewController.swift
+++ b/Alloy/ScanPassportViewController.swift
@@ -155,7 +155,7 @@ internal class ScanPassportViewController: ScanBaseViewController {
             case let .failure(error):
                 print("evaluate", error)
             case let .success(responseE):
-                if !responseE.summary.isApproved {
+                if responseE.summary.hasCardIssue {
                     self?.handleIssue(issue: responseE.summary.outcome)
                 }
             }

--- a/Alloy/SelectDocumentViewController.swift
+++ b/Alloy/SelectDocumentViewController.swift
@@ -126,3 +126,10 @@ internal class SelectDocumentViewController: UIViewController {
         }
     }
 }
+
+internal extension AlloyCardEvaluationResponse.Summary {
+    var canShowEndModal: Bool {
+        guard let _ = EndVariant(rawValue: outcome) else { return false }
+        return true
+    }
+}

--- a/Alloy/SelectDocumentViewController.swift
+++ b/Alloy/SelectDocumentViewController.swift
@@ -126,10 +126,3 @@ internal class SelectDocumentViewController: UIViewController {
         }
     }
 }
-
-internal extension AlloyCardEvaluationResponse.Summary {
-    var canShowEndModal: Bool {
-        guard let _ = EndVariant(rawValue: outcome) else { return false }
-        return true
-    }
-}

--- a/Alloy/Views/EndBanner.swift
+++ b/Alloy/Views/EndBanner.swift
@@ -42,7 +42,9 @@ internal class EndBanner: UIView {
     // MARK: Configure
 
     private func changeVariant() {
-        let animation = Animation.named(variant == .success ? "EndSuccess" : "EndFailure", bundle: .alloy)
+        let showSuccessAnimation = variant == .success || variant == .manualReview
+        let animationName = showSuccessAnimation ? "EndSuccess" : "EndFailure"
+        let animation = Animation.named(animationName, bundle: .alloy)
         animationView.animation = animation
     }
 


### PR DESCRIPTION
Implemented:

- Now the sdk will handle the following outcomes
    - With validationPreChecks = true
        - If the outcome is related to some issue on the picture, it will show the issue on top of the card picture (e.g.: "Too blurry", "Too much glare", "Retake images", etc.)
        - If not, after the final evaluation the end screen will show:
            - Retake Images screen (missing lottie animation!) if the user has ignored the issue before.
            - Manual review, just as the success screen but with a change in the copy.
            - Success and Denied, as usual.
            - For every other outcome the screen will be the same that "Manual Review"
    - With validationPreChecks = false
        - If will show only the final screen after the final evaluation (see above)
        
Some previews:
<details>

<summary> Manual review </summary>
       
https://user-images.githubusercontent.com/48457119/148774223-ec0dbc0f-3544-493b-a4ca-98b3a6a741f5.mov


</details>

<details>

<summary> Retake images (missing animation) </summary>

       

https://user-images.githubusercontent.com/48457119/148774425-7b878744-ee6a-4967-93b0-d1228cb4f328.mov


</details>

        
        